### PR TITLE
Signature inference documentation improvements.

### DIFF
--- a/checker/manual/inference.tex
+++ b/checker/manual/inference.tex
@@ -129,21 +129,22 @@ You can find installation instructions and a video tutorial at \url{https://gith
 
 \subsection{Signature inference\label{signature-inference}}
 
-Elsewhere in this manual, type refinement (Section~\ref{type-refinement})
-has been described as working only within a method. Type refinement always
-refines the current value, regardless of whether the value already has an
-annotated type. Signature inference is an interprocedural inference that
-infer types for fields, method parameters, and method return types that do not
-have an annotated type. The resulting inferred type may not be a type
-refinement. In other words, the inferred type can be a subtype
-or a supertype of the default type. The inferred types can also be inserted into
+Signature inference is an interprocedural inference that
+infers types for fields, method parameters, and method return types that do not
+have a user-written annotation (for the given type system).
+The inferred types are inserted into
 your program.
+The inferred type is the most specific type that is compatible with all the
+uses in the program.  For example, the inferred type for a field is the
+least upper bound of the types of all the expressions that are assigned
+into the field.
 
-To do so, please set the \<\$CHECKERFRAMEWORK> variable to the Checker Framework's
+To use signature inference,
+set the \<\$CHECKERFRAMEWORK> variable to the Checker Framework's
 directory (if you haven't already), and make sure that
 \<insert-annotations-to-source>, from the Annotation File Utilities project,
-is available from the \<\$PATH>.
-Then, run the script \<checker/bin/infer-and-annotate.sh>.
+is on your path (for example in the \<\$PATH> environment variable).
+Then, run the script \<\$CHECKERFRAMEWORK/checker/bin/infer-and-annotate.sh>.
 Its command-line arguments are:
 
 \begin{enumerate}
@@ -158,12 +159,11 @@ Its command-line arguments are:
 \item List of paths to \<.java> files in the program.
 \end{enumerate}
 
-
-
 For example, to add annotations to the \<plume-lib> project:
 \begin{Verbatim}
 git clone https://github.com/mernst/plume-lib.git
 cd plume-lib
+make jar
 $CHECKERFRAMEWORK/checker/bin/infer-and-annotate.sh \
     "LockChecker,NullnessChecker" java/plume.jar    \
     -AprintErrorStack  \
@@ -172,15 +172,33 @@ $CHECKERFRAMEWORK/checker/bin/infer-and-annotate.sh \
 git diff    
 \end{Verbatim}
 
-You may need to wait a few minutes for the command to complete,
-and it will produce voluminous output that you can ignore.
+You may need to wait a few minutes for the command to complete.
 
 It is recommended that you run \<infer-and-annotate.sh> on a copy of your
 code, so that you can see what changes it made and so that it does not
 change your only copy.  One way to do this is to work in a clone of your
 repository that has no uncommitted changes.
 
-As with any type inference tool, it is a good idea to double-check the
+Signature inference ignores code within the the scope of a
+\<@SuppressWarnings> annotation with an appropriate key
+(Section~\ref{suppresswarnings-annotation}).  In particular, uses within
+the scope do not contribute to the inferred type, and declarations within
+the scope are not changed.  You should remove \<@SuppressWarnings> annotations
+from the class declaration of any class you wish to infer types for.
+
+Signature inference differs from type refinement (Section~\ref{type-refinement})
+in three ways.  First, type refinement only works within a method body.
+Second, type refinement always
+refines the current type, regardless of whether the value already has an
+annotation in the source code.
+Third, signature inference can infer a subtype
+or a supertype of the default type, by contrast with type refinement which
+always refines the current type to a subtype.
+
+
+\subsubsection{Manually checking signature inference results\label{signature-inference-manual-checking}}
+
+As with any type inference tool, it is a good idea to manually examine the
 results.
 For example, suppose that your program currently calls
 method \<m1> with non-null
@@ -202,8 +220,10 @@ currently written but may not be as general as possible and may not
 accommodate future program changes.  If the program contains errors, the
 tool's annotations may reflect those errors.
 
-The tool only infers annotations for type uses that have no user-written
-annotation (for the given type system).
+Also carefully examine annotations inferred for uses of type variables; in
+some cases, it might be more appropriate for you to move those annotations
+to the corresponding upper bounds of the type variable declaration.
+
 
 \subsubsection{How signature inference works\label{how-signature-inference-works}}
 
@@ -255,4 +275,4 @@ it makes type-checking fast.  However, it has some disadvantages:
 
 
 %%  LocalWords:  AinferSignatures java jaif plugin classpath m2 m1 multi
-%%  LocalWords:  AsuggestPureMethods
+%%  LocalWords:  AsuggestPureMethods CHECKERFRAMEWORK


### PR DESCRIPTION
Signature inference doesn't look inside scope of @SuppressWarnings.
Move comparisons later in section.
Fix example command.
Warn about poor behavior for uses of type variables.
